### PR TITLE
refactor(api): display external API if user is signed out, closes #32

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@ import { createClient } from "@/utils/supabase/server"
 import { cookies } from "next/headers"
 
 import InspirationalQuote from "../components/InspirationalQuote"
+import { createServerComponentClient } from "@supabase/auth-helpers-nextjs"
 
 export default async function Index() {
   const cookieStore = cookies()

--- a/components/InspirationalQuote.tsx
+++ b/components/InspirationalQuote.tsx
@@ -1,13 +1,26 @@
+import { createServerComponentClient } from "@supabase/auth-helpers-nextjs"
+import { cookies } from "next/headers"
+
 export default async function Index() {
   const res = await fetch("https://official-joke-api.appspot.com/random_joke")
   const data = await res.json()
   const setup = data.setup
   const punchline = data.punchline
 
+  const supabase = createServerComponentClient({ cookies })
+
+  const {
+    data: { user }
+  } = await supabase.auth.getUser()
+
   return (
     <div className="flex flex-col items-center">
-      <pre>{setup}</pre>
-      <pre>{punchline}</pre>
+      {user ? null : (
+        <div className="flex flex-col items-center">
+          <pre>{setup}</pre>
+          <pre>{punchline}</pre>
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
Only display a randomly picked joke from an external API if the user is not signed in.

For signed in users, this shall be replaced with a section to display user's recently viewed forms. The `null` currently acts as a placeholder.