### PR TITLE
feat: add sample data to each table, closes #27

### DIFF
--- a/supabase/migrations/20231116121936_form.sql
+++ b/supabase/migrations/20231116121936_form.sql
@@ -7,7 +7,6 @@ form (
   status int not null,
   created timestamp not null,
   updated timestamp,
-  is_deleted boolean not null,
   deleted timestamp
 );
 

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -4,3 +4,23 @@ values
 ('Nature'),
 ('History'),
 ('Math');
+
+insert into
+form (category_id, title, description, status, created)
+values
+(1, "Cats", "Test your knowledge of everyones faveourite pet!", 1, '2023-11-16 13:13:20'),
+(3, "Irrational numbers", "A form on irrational numbers for total beginners.", 3, '2023-11-19 15:16:50');
+
+insert into
+question (form_id, title, answer, photo_url, is_evaluable)
+values
+(1, "What breed of cat is this?", "Domestic shorthair", "https://cdn.mos.cms.futurecdn.net/2fw95nMhZqLGohDSUbLunn-1200-80.jpg.webp", TRUE),
+(1, "How long do cats typically live?", "13-17 years", null, FALSE),
+(2, "Rational numbers are the opposite to ...?", "rational numbers", null, TRUE),
+(2, "Is this an irrational number?", "yes", "https://images.saymedia-content.com/.image/t_share/MTc5OTc2MzEwNjQ1MzM1Mzg0/how-to-prove-that-the-square-root-of-2-is-irrational.jpg", TRUE);
+
+insert into
+history (form_id, lastViewed)
+values
+(1, '2023-11-16 16:13:20'),
+(2, '2023-11-19 15:19:50');


### PR DESCRIPTION
Added sample data for the following tables: `category`, `form`, `question`, `history`.

Also removed `is_deleted` attribute from `form` table, since `deleted` attribute already indicates whether or not this has been removed.