### PR TITLE
feat: read categories and forms on main page, closes #34

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,14 +3,24 @@ import { cookies } from "next/headers"
 
 import InspirationalQuote from "../components/InspirationalQuote"
 import { createServerComponentClient } from "@supabase/auth-helpers-nextjs"
+import ShowCategories from "@/components/database/ShowCategories"
+
+
 
 export default async function Index() {
-  const cookieStore = cookies()
+  const supabase = createServerComponentClient({ cookies })
+
+
+  const { data: forms } = await supabase.from("form").select().eq("category_id", 1)
+
+  console.log(forms)
+
 
   return (
     <div className="flex-1 flex flex-col w-full px-8 sm:max-w-md justify-center gap-2">
       <h1 className="flex flex-col items-center">main page</h1>
       <InspirationalQuote />
+      <ShowCategories />
     </div>
   )
 }

--- a/components/database/GetCategories.tsx
+++ b/components/database/GetCategories.tsx
@@ -1,0 +1,26 @@
+
+import { cookies } from "next/headers"
+import { createServerComponentClient } from '@supabase/auth-helpers-nextjs'
+
+import ShowForms from "./ShowForms"
+
+
+
+export default async function GetCategories() {
+  const supabase = createServerComponentClient({ cookies })
+
+	const { data: categories } = await supabase.from("category").select()
+		if (!categories) {
+		return <p>No categories found</p>
+	}
+	
+
+	return (
+			categories.map((category) => (
+				<div>
+					<h3>{category.name}</h3>
+					<ShowForms categoryID={category.id} />
+				</div>
+			))
+	)
+}

--- a/components/database/GetForms.tsx
+++ b/components/database/GetForms.tsx
@@ -1,0 +1,20 @@
+
+import { cookies } from "next/headers"
+import { createServerComponentClient } from "@supabase/auth-helpers-nextjs"
+
+
+export default async function GetForms({categoryID}: any) {
+  const supabase = createServerComponentClient({ cookies })
+
+	const { data: forms } = await supabase.from("form").select().eq('category_id', categoryID)
+		if (!forms) {
+		return <p>No forms found</p>
+	}
+
+	return (
+			forms.map((form) => (
+					<h5>{form.title}</h5>
+			))
+	)
+}
+  

--- a/components/database/ShowCategories.tsx
+++ b/components/database/ShowCategories.tsx
@@ -1,0 +1,17 @@
+
+import { List } from '@mui/material'
+import { createClientComponentClient } from '@supabase/auth-helpers-nextjs'
+import GetCategories from './GetCategories'
+
+
+
+export default function ShowCategories() {
+
+	const supabase = createClientComponentClient()
+		
+
+	return (
+			<GetCategories />
+	)
+		
+  }

--- a/components/database/ShowForms.tsx
+++ b/components/database/ShowForms.tsx
@@ -1,0 +1,21 @@
+
+import { Box, List } from '@mui/material'
+import AdjustIcon from '@mui/icons-material/Adjust';
+import { createClientComponentClient } from '@supabase/auth-helpers-nextjs'
+import GetForms from './GetForms'
+
+
+
+export default function ShowForms({categoryID}: any) {
+
+	const supabase = createClientComponentClient()
+		
+
+	return (
+		<Box sx={{ display: 'flex' }}>
+			<AdjustIcon />
+			<GetForms categoryID={categoryID}/>
+		</Box>
+	)
+		
+}

--- a/supabase/migrations/20231115163805_category.sql
+++ b/supabase/migrations/20231115163805_category.sql
@@ -5,3 +5,7 @@ category (
 );
 
 alter table category enable row level security;
+
+create policy "Categories are viewable by everyone."
+  on public.category for select
+  using ( true );

--- a/supabase/migrations/20231116121936_form.sql
+++ b/supabase/migrations/20231116121936_form.sql
@@ -14,3 +14,7 @@ alter table favorite
   add column form_id bigint not null references form;
 
 alter table form enable row level security;
+
+create policy "Forms are viewable by everyone."
+  on public.form for select
+using ( true );


### PR DESCRIPTION
🤯

Categories and their forms are shown on front page. It might be stupid way to do this but atleast it works... 
Added RLS policies to form and category tables.