### PR TITLE
bugfix: sign out works again, closes #73

### DIFF
--- a/components/AuthButton.tsx
+++ b/components/AuthButton.tsx
@@ -26,9 +26,13 @@ export default function AuthButton() {
   if (userDataLoaded) {
     return userData ? (
       <Box>
-        <form action={async () => {await supabase.auth.signOut()}}>
+        <form 
+          action={async () => {
+            await supabase.auth.signOut() 
+            window.location.href = "/"
+          }}
+        >
           <Button 
-            href="/login"
             className="py-2 px-4 rounded-md no-underline"
             variant="contained"
             color="primary"


### PR DESCRIPTION
Fixed error - user was not signed out when button was clicked
Now when user clicks sign out, they are signed out and redirected to main page 