### PR TITLE
feat: add character limit for textfields, closes #117

### DIFF
--- a/app/createForm/page.jsx
+++ b/app/createForm/page.jsx
@@ -92,6 +92,9 @@ export default function CreateForm() {
           label="Nimi"
           id="formName"
           value={formTitle}
+          inputProps={{
+            maxLength: 30,
+          }}
           onChange={(e) => setFormTitle(e.target.value)}
         />
         <br />
@@ -102,6 +105,9 @@ export default function CreateForm() {
           label="Kirjeldus"
           id="formDescription"
           value={formDescription}
+          inputProps={{
+            maxLength: 75,
+          }}
           onChange={(e) => setFormDescription(e.target.value)}
         />
         <br />


### PR DESCRIPTION
Added a maximum limit of `30` characters for the `title` and `75` characters for the `description`. These limits should be generous enough for an user and prevent our current design from bugging out.

Since this is a simple change, I'll redo it if it conflicts with our `app/createPage` file.