### PR TITLE
feat: add suggested forms, closes #103

### DIFF
--- a/components/MainPageForms.jsx
+++ b/components/MainPageForms.jsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { Typography, Button, Grid } from "@mui/material";
 import ShowUserForms from "./ShowUserForms";
+import SuggestedForms from "./SuggestedForms";
 
 export default function MainPageCategories() {
   const supabase = createClientComponentClient();
@@ -73,6 +74,7 @@ export default function MainPageCategories() {
   return (
     <>
       {userID != 0 && <ShowUserForms />}
+      <SuggestedForms />
       <Grid
         container
         spacing={2}

--- a/components/MainPageForms.jsx
+++ b/components/MainPageForms.jsx
@@ -75,6 +75,9 @@ export default function MainPageCategories() {
     <>
       {userID != 0 && <ShowUserForms />}
       <SuggestedForms />
+      <Typography variant="h4" sx={{ margin: "25px 0" }}>
+        Kategooriad
+      </Typography>
       <Grid
         container
         spacing={2}

--- a/components/MainPageForms.jsx
+++ b/components/MainPageForms.jsx
@@ -76,7 +76,7 @@ export default function MainPageCategories() {
       {userID != 0 && <ShowUserForms />}
       <SuggestedForms />
       <Typography variant="h4" sx={{ margin: "25px 0" }}>
-        Kategooriad
+        Sirvi kategooriate kaupa
       </Typography>
       <Grid
         container

--- a/components/ShowUserForms.tsx
+++ b/components/ShowUserForms.tsx
@@ -113,96 +113,94 @@ export default function ShowUserForms() {
 
   return (
     <>
-    <Typography variant="h4" sx={{ margin: "25px 0" }}>
-      Sinu küsimustikud
-    </Typography>
-    <Grid
-      container
-      sx={{
-        display: "grid",
-        gridTemplateColumns: "repeat(auto-fill, minmax(350px, 1fr))",
-        gap: "16px",
-        justifyContent: "space-between",
-        alignItems: "baseline",
-      }}
-    >
-      {forms.map((form) => (
-        <Grid
-          item
-          key={form.id}
-          sx={{
-            display: "flex",
-            flexDirection: "column",
-            border: 1,
-            borderColor: "primary.main",
-            boxShadow: 1,
-            borderRadius: 2,
-            p: 2,
-            m: 1,
-            width: 350,
-            height: 200,
-          }}
-        >
-          <Box
+      <Typography variant="h4" sx={{ margin: "25px 0" }}>
+        Sinu küsimustikud
+      </Typography>
+      <Grid
+        container
+        sx={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "baseline",
+        }}
+      >
+        {forms.map((form) => (
+          <Grid
+            item
+            key={form.id}
             sx={{
               display: "flex",
-              flexDirection: "row",
-              justifyContent: "space-between",
+              flexDirection: "column",
+              border: 1,
+              borderColor: "primary.main",
+              boxShadow: 1,
+              borderRadius: 2,
+              p: 2,
+              marginBottom: 3.5,
+              width: 345,
+              height: 200,
             }}
           >
-            <Button
-              key={form.id}
+            <Box
               sx={{
+                display: "flex",
+                flexDirection: "row",
+                justifyContent: "space-between",
+              }}
+            >
+              <Button
+                key={form.id}
+                sx={{
+                  justifyContent: "flex-start",
+                  width: "fit-content",
+                  mr: 2,
+                }}
+                variant="outlined"
+                color="primary"
+                onClick={() => handleClick(form.id)}
+              >
+                {form.title}
+              </Button>
+              <Tooltip title="Kustuta" placement="right" arrow>
+                <DeleteOutlineIcon
+                  onClick={() => deleteForm(form.id)}
+                  sx={{
+                    color: "red",
+                    cursor: "pointer",
+                    height: "1.25em",
+                  }}
+                />
+              </Tooltip>
+            </Box>
+            <Typography sx={{ minHeight: "60px", margin: "0.65em 0" }}>
+              {form.description}
+            </Typography>
+            <FormControl
+              sx={{
+                mt: 1,
+                mb: 2,
+                minWidth: 200,
                 justifyContent: "flex-start",
                 width: "fit-content",
-                mr: 2,
               }}
-              variant="outlined"
-              color="primary"
-              onClick={() => handleClick(form.id)}
+              size="small"
             >
-              {form.title}
-            </Button>
-            <Tooltip title="Kustuta" placement="right" arrow>
-              <DeleteOutlineIcon
-                onClick={() => deleteForm(form.id)}
-                sx={{
-                  color: "red",
-                  cursor: "pointer",
-                  height: "1.25em",
-                }}
-              />
-            </Tooltip>
-          </Box>
-          <Typography sx={{ minHeight: "60px", margin: "0.65em 0" }}>
-            {form.description}
-          </Typography>
-          <FormControl
-            sx={{
-              mt: 1,
-              mb: 2,
-              minWidth: 200,
-              justifyContent: "flex-start",
-              width: "fit-content",
-            }}
-            size="small"
-          >
-            <InputLabel id="formStatus">Olek</InputLabel>
-            <Select
-              labelId="formStatusLabel"
-              id="formStatus"
-              value={form.status}
-              label="Olek"
-              onChange={(event) => handleStatusChange(form.id, event)}
-            >
-              <MenuItem value={1}>Privaatne</MenuItem>
-              <MenuItem value={2}>Kontodega kasutajad</MenuItem>
-              <MenuItem value={3}>Avalik</MenuItem>
-            </Select>
-          </FormControl>
-        </Grid>
-      ))}
-    </Grid>
+              <InputLabel id="formStatus">Olek</InputLabel>
+              <Select
+                labelId="formStatusLabel"
+                id="formStatus"
+                value={form.status}
+                label="Olek"
+                onChange={(event) => handleStatusChange(form.id, event)}
+              >
+                <MenuItem value={1}>Privaatne</MenuItem>
+                <MenuItem value={2}>Kontodega kasutajad</MenuItem>
+                <MenuItem value={3}>Avalik</MenuItem>
+              </Select>
+            </FormControl>
+          </Grid>
+        ))}
+      </Grid>
     </>
   );
 }

--- a/components/SuggestedForms.tsx
+++ b/components/SuggestedForms.tsx
@@ -3,19 +3,7 @@
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
-import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
-import {
-  Box,
-  Grid,
-  Button,
-  FormControl,
-  InputLabel,
-  MenuItem,
-  Select,
-  SelectChangeEvent,
-  Tooltip,
-  Typography,
-} from "@mui/material";
+import { Box, Grid, Button, Typography } from "@mui/material";
 import { format } from "date-fns";
 
 interface Form {
@@ -83,41 +71,6 @@ export default function ShowUserForms() {
 
   const handleClick = (id: number) => {
     router.push(`../form?form_id=${id}`);
-  };
-
-  const handleStatusChange = async (
-    id: number,
-    event: SelectChangeEvent<number>
-  ) => {
-    const newStatus = event.target.value;
-    const currentTimestamp = format(new Date(), "yyyy-MM-dd HH:mm:ss");
-    console.log("Changing status for form id", id, "to", newStatus);
-    const { data, error } = await supabase
-      .from("form")
-      .update({ status: newStatus, updated: currentTimestamp })
-      .match({ id: id })
-      .select();
-    if (error) {
-      console.error("Error updating status:", error);
-    } else {
-      console.log("Updated form:", data);
-    }
-    getForms();
-  };
-
-  const deleteForm = async (id: number) => {
-    const currentTimestamp = format(new Date(), "yyyy-MM-dd HH:mm:ss");
-    const { data, error } = await supabase
-      .from("form")
-      .update({ deleted: currentTimestamp })
-      .match({ id: id })
-      .select();
-    if (error) {
-      console.error("Error updating delete:", error);
-    } else {
-      console.log("Deleted form:", data);
-      getForms();
-    }
   };
 
   return (

--- a/components/SuggestedForms.tsx
+++ b/components/SuggestedForms.tsx
@@ -76,7 +76,7 @@ export default function ShowUserForms() {
   return (
     <>
       <Typography variant="h4" sx={{ margin: "25px 0" }}>
-        Soovitatud küsimustikud
+        Sinule soovitatud
       </Typography>
       <Grid
         container

--- a/components/SuggestedForms.tsx
+++ b/components/SuggestedForms.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
+import {
+  Box,
+  Grid,
+  Button,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  SelectChangeEvent,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import { format } from "date-fns";
+
+interface Form {
+  id: number;
+  title: string;
+  description: string;
+}
+
+export default function ShowUserForms() {
+  const supabase = createClientComponentClient();
+  const router = useRouter();
+
+  const [userID, setUserID] = useState("");
+  const [userIDLoaded, setUserIDLoaded] = useState(false);
+
+  useEffect(() => {
+    const getUserID = async () => {
+      const { data } = await supabase.auth.getSession();
+      //console.log(data.session)
+      if (data.session != null) {
+        const id = data.session.user.id;
+        setUserID(id);
+      } else {
+        console.log("123");
+        setUserID("0");
+      }
+      setUserIDLoaded(true);
+    };
+    getUserID();
+  }, []);
+
+  const [forms, setForms] = useState<Form[]>([]);
+
+  const getForms = async () => {
+    const currentTimestamp = format(new Date(), "yyyy-MM-dd HH:mm:ss");
+    let data;
+    if (userID === "0") {
+      ({ data } = await supabase
+        .from("form")
+        .select()
+        .or(`deleted.is.null,deleted.gt.${currentTimestamp}`)
+        .order("created", { ascending: false }));
+    } else {
+      ({ data } = await supabase
+        .from("form")
+        .select()
+        .or(`user_id.neq.${userID},user_id.is.null`)
+        .or(`deleted.is.null,deleted.gt.${currentTimestamp}`)
+        .order("created", { ascending: false })
+        .limit(3));
+    }
+    if (data) {
+      setForms(data);
+    }
+  };
+
+  //console.log(userID)
+
+  useEffect(() => {
+    if (userIDLoaded) {
+      getForms();
+      //console.log(userIDLoaded, userID)
+    }
+  }, [userID]);
+
+  const handleClick = (id: number) => {
+    router.push(`../form?form_id=${id}`);
+  };
+
+  const handleStatusChange = async (
+    id: number,
+    event: SelectChangeEvent<number>
+  ) => {
+    const newStatus = event.target.value;
+    const currentTimestamp = format(new Date(), "yyyy-MM-dd HH:mm:ss");
+    console.log("Changing status for form id", id, "to", newStatus);
+    const { data, error } = await supabase
+      .from("form")
+      .update({ status: newStatus, updated: currentTimestamp })
+      .match({ id: id })
+      .select();
+    if (error) {
+      console.error("Error updating status:", error);
+    } else {
+      console.log("Updated form:", data);
+    }
+    getForms();
+  };
+
+  const deleteForm = async (id: number) => {
+    const currentTimestamp = format(new Date(), "yyyy-MM-dd HH:mm:ss");
+    const { data, error } = await supabase
+      .from("form")
+      .update({ deleted: currentTimestamp })
+      .match({ id: id })
+      .select();
+    if (error) {
+      console.error("Error updating delete:", error);
+    } else {
+      console.log("Deleted form:", data);
+      getForms();
+    }
+  };
+
+  return (
+    <>
+      <Typography variant="h4" sx={{ margin: "25px 0" }}>
+        Soovitatud küsimustikud
+      </Typography>
+      <Grid
+        container
+        sx={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fill, minmax(350px, 1fr))",
+          gap: "16px",
+          justifyContent: "space-between",
+          alignItems: "baseline",
+        }}
+      >
+        {forms.map((form) => (
+          <Grid
+            item
+            key={form.id}
+            sx={{
+              display: "flex",
+              flexDirection: "column",
+              border: 1,
+              borderColor: "primary.main",
+              boxShadow: 1,
+              borderRadius: 2,
+              p: 2,
+              m: 1,
+              width: 350,
+              height: 125,
+            }}
+          >
+            <Box
+              sx={{
+                display: "flex",
+                flexDirection: "row",
+                justifyContent: "space-between",
+              }}
+            >
+              <Button
+                key={form.id}
+                sx={{
+                  justifyContent: "flex-start",
+                  width: "fit-content",
+                  mr: 2,
+                }}
+                variant="outlined"
+                color="primary"
+                onClick={() => handleClick(form.id)}
+              >
+                {form.title}
+              </Button>
+            </Box>
+            <Typography sx={{ minHeight: "60px", margin: "0.65em 0" }}>
+              {form.description}
+            </Typography>
+          </Grid>
+        ))}
+      </Grid>
+    </>
+  );
+}

--- a/components/SuggestedForms.tsx
+++ b/components/SuggestedForms.tsx
@@ -81,9 +81,7 @@ export default function ShowUserForms() {
       <Grid
         container
         sx={{
-          display: "grid",
-          gridTemplateColumns: "repeat(auto-fill, minmax(350px, 1fr))",
-          gap: "16px",
+          display: "flex",
           justifyContent: "space-between",
           alignItems: "baseline",
         }}
@@ -100,8 +98,8 @@ export default function ShowUserForms() {
               boxShadow: 1,
               borderRadius: 2,
               p: 2,
-              m: 1,
-              width: 350,
+              marginBottom: 3.5,
+              width: 345,
               height: 125,
             }}
           >

--- a/components/SuggestedForms.tsx
+++ b/components/SuggestedForms.tsx
@@ -45,7 +45,8 @@ export default function ShowUserForms() {
         .from("form")
         .select()
         .or(`deleted.is.null,deleted.gt.${currentTimestamp}`)
-        .order("created", { ascending: false }));
+        .order("created", { ascending: false })
+        .limit(3));
     } else {
       ({ data } = await supabase
         .from("form")


### PR DESCRIPTION
Show suggested forms on the front page for everyone (including for not logged in users). Suggested forms are the topmost recent forms that are not created by the signed in user.

Also changed some margins and improved styling to better fit with main page design.

Gave a title for `MainPageForms` for better UX.