### PR TITLE
fix: limit user forms on front page, closes #109

### DIFF
--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -94,7 +94,7 @@ export default function Profile() {
             Sinu lemmikud
           </Typography>
           <ShowUserFavorites />
-          <ShowUserForms />
+          <ShowUserForms limit={100}/>
         </Grid>
       </Container>
     ) : (

--- a/components/MainPageForms.jsx
+++ b/components/MainPageForms.jsx
@@ -73,7 +73,7 @@ export default function MainPageCategories() {
 
   return (
     <>
-      {userID != 0 && <ShowUserForms />}
+      {userID != 0 && <ShowUserForms limit={3}/>}
       <SuggestedForms />
       <Typography variant="h4" sx={{ margin: "25px 0" }}>
         Sirvi kategooriate kaupa

--- a/components/ShowUserForms.tsx
+++ b/components/ShowUserForms.tsx
@@ -25,7 +25,7 @@ interface Form {
   status: number;
 }
 
-export default function ShowUserForms() {
+export default function ShowUserForms({limit}: any) {
   const supabase = createClientComponentClient();
   const router = useRouter();
 
@@ -57,7 +57,8 @@ export default function ShowUserForms() {
       .select()
       .eq("user_id", userID)
       .or(`deleted.is.null,deleted.gt.${currentTimestamp}`)
-      .order("id", { ascending: true });
+      .order("id", { ascending: true })
+      .limit(limit)
     if (data) {
       setForms(data);
     }


### PR DESCRIPTION
Added limit to `ShowUserForms`, on front page it is 3, and on profile page I put 100. I think this is enough for users