### PR TITLE
fix: no headings until data fetched, closes #142

### DIFF
--- a/components/MainPageForms.jsx
+++ b/components/MainPageForms.jsx
@@ -81,10 +81,10 @@ export default function MainPageCategories() {
   return (
     <>
       {userID != 0 && <ShowUserForms limit={3}/>}
-      <SuggestedForms />
-      <Typography variant="h4" sx={{ margin: "25px 0" }}>
+      {userIDLoaded && <SuggestedForms />}
+      {userIDLoaded && <Typography variant="h4" sx={{ margin: "25px 0" }}>
         Sirvi kategooriate kaupa
-      </Typography>
+      </Typography>}
       <Grid
         container
         spacing={2}

--- a/components/ViewQuestion.jsx
+++ b/components/ViewQuestion.jsx
@@ -256,7 +256,7 @@ export default function ViewQuestion() {
         }}
       >
         <Typography variant="h1">{formTitle}</Typography>
-        {userID != 0 && (
+        {(userIDLoaded && userID != 0) && (
           <IconButton onClick={saveNewFavorite}>
             <StarIcon
               fontSize="large"


### PR DESCRIPTION
Added checks to headings on front page, if data is loaded
Same to viewquestions favorite icon if user is signed in